### PR TITLE
forcing the eventType to be PageAction. If you use the directives of …

### DIFF
--- a/lib/angulartics-newrelic-insights.js
+++ b/lib/angulartics-newrelic-insights.js
@@ -16,8 +16,11 @@
     .config(['$analyticsProvider', function($analyticsProvider) {
       angulartics.waitForVendorApi('newrelic', 100, function(newrelic) {
         $analyticsProvider.registerEventTrack(function(action, properties) {
-          properties.eventType = 'PageAction';
-          newrelic.addPageAction(action, properties);
+          var propertiesCopy = angular.copy(properties);
+          if (propertiesCopy.eventType === 'click') {
+              propertiesCopy.eventType = 'PageAction';
+          }
+          newrelic.addPageAction(action, propertiesCopy);
         });
         $analyticsProvider.registerSetUsername(function(name) {
           newrelic.setCustomAttribute('username', name);

--- a/lib/angulartics-newrelic-insights.js
+++ b/lib/angulartics-newrelic-insights.js
@@ -16,6 +16,7 @@
     .config(['$analyticsProvider', function($analyticsProvider) {
       angulartics.waitForVendorApi('newrelic', 100, function(newrelic) {
         $analyticsProvider.registerEventTrack(function(action, properties) {
+          properties.eventType = 'PageAction';
           newrelic.addPageAction(action, properties);
         });
         $analyticsProvider.registerSetUsername(function(name) {


### PR DESCRIPTION
…angulartics on href the eventType will be click. New Relic is not accept that as valid.